### PR TITLE
Change plugins version to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@eth-optimism/dev": "^1.1.1",
-    "@eth-optimism/plugins": "^1.0.0-alpha.2",
+    "@eth-optimism/plugins": "latest",
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "chai": "^4.2.0",


### PR DESCRIPTION
Using “latest” should remove the need to update the plugins version whenever we bump plugins.